### PR TITLE
Honor error code in response

### DIFF
--- a/src/convertResponse.spec.ts
+++ b/src/convertResponse.spec.ts
@@ -159,8 +159,6 @@ describe('convertResponse()', () => {
       expect(res.send).toHaveBeenCalledWith(defaultResponse.body);
       expect(res.status).toBeCalledTimes(1);
       expect(res.status).toHaveBeenCalledWith(defaultResponse.statusCode);
-      expect(res.end).toBeCalledTimes(1);
-      expect(res.end).toHaveBeenCalledWith();
     });
 
     it('should set a default statusCode', () => {

--- a/src/convertResponse.ts
+++ b/src/convertResponse.ts
@@ -104,10 +104,9 @@ export function convertResponseFactory({
       const coerced = isObject(response) && 'body' in response ? coerceBody(response.body) : coerceBody(response);
       logger.info('End - Result:');
       logger.info(coerced);
-      res.send(coerced);
 
       const statusCode = isObject(response) && !!response.statusCode ? parseInt(`${response.statusCode}`) : 200;
-      return res.status(statusCode).end();
+      return res.status(statusCode).send(coerced);
     } catch (error) {
       return sendError(error as Error);
     }


### PR DESCRIPTION
I noticed when using the library that it would always return HTTP-200, regardless of what the lambda returns.

This PR addresses this, by (a) removing the premature `res.send()` and (b) replacing the `res.end()` with `res.send()`.